### PR TITLE
Add codiceIPA key to publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -30,6 +30,8 @@ description:
     shortDescription: Tipo di contenuto notizia aggiuntivo
 developmentStatus: stable
 it:
+  riuso:
+    codiceIPA: r_emiro
   conforme:
     gdpr: true
     lineeGuidaDesign: false


### PR DESCRIPTION
This PR:
* adds the `codiceIPA` key to the `publiccode.yml` file.

@nzambello please see that the validator is still failing due to this:
```
validation ko:
description/it/longDescription: too short (375), min 500 chars
```
Could you please provide the extra chars needed? Thanks a lot!